### PR TITLE
Cut a 0.1.9 release to fix async issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages  # noqa: H301
 
 
 NAME = 'ynab_client'
-VERSION = '0.1.8'
+VERSION = '0.1.9'
 
 REQUIRES = [
     'urllib3 >= 1.15',


### PR DESCRIPTION
Using:

```
[tool.poetry.dependencies]
ynab_client = "^0.1.8"
```

My machine ends up with an old copy of this package that hasn't fixed all the python 3.7 issues from the reserved async keyword. I [manually fixed these locally](https://github.com/gchiam/ynab-client-python/compare/master...Pezmc:python-3.7-compatibility?expand=1) ready to open a PR before I realised they've already been fixed (https://github.com/gchiam/ynab-client-python/pull/12), just not released.

This PR updates the version number so consumers can ensure they're getting a python 3.7 compatible version.